### PR TITLE
Add short_name to manifest in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -105,7 +105,7 @@ runs:
 
             const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
             manifest["configuration"] = pluginSettingsSchema;
-            manifest["short_name"] = `${{ GITHUB_REPOSITORY }}@${{ GITHUB_REF_NAME }}`;
+            manifest["short_name"] = `${{ github.repository }}@${{ github.ref_name }}`;
 
             function customReviver(key, value) {
               if (typeof value === "object" && value !== null) {


### PR DESCRIPTION
Resolves #25

QA: https://github.com/Meniole/command-wallet/commit/ba72c336661d811700b5e95a90a4a3be3578e61b

This will help to identify plugins based on their actual `owner/repo@branch` location which in turn will help the SDK properly identifying them.

Also follows `manifest.json` naming conventions: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/short_name

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
